### PR TITLE
Fix: Check instance type before casting

### DIFF
--- a/cli/src/main/java/org/openbaton/cli/util/PrintFormat.java
+++ b/cli/src/main/java/org/openbaton/cli/util/PrintFormat.java
@@ -207,7 +207,8 @@ public class PrintFormat {
                   objectHash.add(lvlDown);
 
                 } else {
-                  objectHash = (Set<Object>) lvlDown;
+                  if (lvlDown instanceof ArrayList) objectHash = new HashSet<>((ArrayList) lvlDown);
+                  else objectHash = (Set<Object>) lvlDown;
                 }
 
                 for (Object obj : objectHash) {


### PR DESCRIPTION
The lifecycle event history object is an ArrayList and the PrintFormat class tried to cast it to a Set. This fixes #9.