### PR TITLE
Fix: Prevent addVNFCInstance from printing an error message even thou…

### DIFF
--- a/cli/src/main/java/org/openbaton/cli/util/PrintFormat.java
+++ b/cli/src/main/java/org/openbaton/cli/util/PrintFormat.java
@@ -52,7 +52,8 @@ public class PrintFormat {
       if (!command.contains("delete")
           && !command.contains("changePassword")
           && !command.contains("startVNFCInstance")
-          && !command.contains("stopVNFCInstance")) {
+          && !command.contains("stopVNFCInstance")
+          && !command.contains("createVNFCInstance")) {
         result = "Error: invalid command line";
       }
       return result;


### PR DESCRIPTION
…gh the command succeeds

This closes #7.