### PR TITLE
Fix: Trim whitespaces and new line characters from the service token

### DIFF
--- a/sdk/src/main/java/org/openbaton/sdk/api/util/RestRequest.java
+++ b/sdk/src/main/java/org/openbaton/sdk/api/util/RestRequest.java
@@ -196,7 +196,7 @@ public abstract class RestRequest {
     this.serviceName = serviceName;
     this.isService = true;
     this.projectId = projectId;
-    this.serviceKey = serviceKey;
+    this.serviceKey = serviceKey.trim();
 
     GsonBuilder builder = new GsonBuilder();
     //    builder.registerTypeAdapter(Date.class, new GsonSerializerDate());
@@ -1158,6 +1158,4 @@ public abstract class RestRequest {
         .setSSLSocketFactory(sslConnectionSocketFactory)
         .build();
   }
-
-  public static void main(String[] args) {}
 }


### PR DESCRIPTION
Copying the key may result in additional new line characters or white spaces due to which the service registration can fail.